### PR TITLE
[#21] fix: Brush이동시 필터 하이라이팅 오류 해결

### DIFF
--- a/src/components/MainChart.tsx
+++ b/src/components/MainChart.tsx
@@ -22,6 +22,11 @@ interface MainChartProps {
 
 const MainChart = ({ datas, idSelect, onChange }: MainChartProps) => {
   const [activeIndex, setActiveIndex] = useState<number[] | undefined>([]);
+  const [brushIndex, setBrushIndex] = useState<number[]>([]);
+
+  useEffect(() => {
+    setBrushIndex([0, datas.length - 1]);
+  }, [datas]);
 
   useEffect(() => {
     setActiveIndex(
@@ -71,14 +76,6 @@ const MainChart = ({ datas, idSelect, onChange }: MainChartProps) => {
         label={{ value: `value_area`, position: 'top', offset: 15 }}
       />
 
-      <Area
-        yAxisId='value_area'
-        dataKey='value_area'
-        type='monotone'
-        fill='url(#color1)'
-        fillOpacity={1}
-        stroke='#ffb700'
-      />
       <Bar
         yAxisId='value_bar'
         dataKey='value_bar'
@@ -87,15 +84,35 @@ const MainChart = ({ datas, idSelect, onChange }: MainChartProps) => {
         radius={[3, 3, 0, 0]}
         animationEasing={'ease-in-out'}
       >
-        {datas.map((entry, index) => (
-          <Cell
-            key={`cell-${index}`}
-            fill={activeIndex?.includes(index) ? '#F4BE37' : 'url(#color2)'}
-          />
-        ))}
+        {datas.map((entry, index) => {
+          if (index >= brushIndex[0] && index <= brushIndex[1]) {
+            return (
+              <Cell
+                key={`cell-${index}`}
+                fill={activeIndex?.includes(index) ? '#F4BE37' : 'url(#color2)'}
+              />
+            );
+          }
+        })}
       </Bar>
+      <Area
+        yAxisId='value_area'
+        dataKey='value_area'
+        type='monotone'
+        fill='url(#color1)'
+        fillOpacity={1}
+        stroke='#ffb700'
+      />
 
-      <Brush dataKey='date' height={30} stroke='#5388D899' />
+      <Brush
+        dataKey='date'
+        height={30}
+        stroke='#5388D899'
+        onChange={e => {
+          if (!e.startIndex || !e.endIndex) return;
+          setBrushIndex([e.startIndex, e.endIndex]);
+        }}
+      />
 
       <defs>
         <linearGradient id='color1' x1='0' y1='1.5' x2='0' y2='0'>


### PR DESCRIPTION
## 요구사항
- [x] Brush이동시 원하지않는 bar차트 하이라이트 오류

## 구현 사항 설명
Brush이동시 보여지는 차트의 index변경이 되어 Bar안에서 data.map하여 만든 Cell이 원하지않는 상태로 보여지는 오류 Brush이동시 startindex,endindex를 state값으로 저장해두어 해당 index안에 있는 데이터만 그리도록 하여 해결
## 성장 포인트 & 보완 할 점 (option)

[관련 스크린샷 첨부]

