### PR TITLE
[#39] refactor: 일자별 데이터 가공 추가

### DIFF
--- a/src/components/chart/MainChart.tsx
+++ b/src/components/chart/MainChart.tsx
@@ -1,20 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Bar,
-  XAxis,
-  Tooltip,
-  YAxis,
-  Legend,
-  Area,
-  ComposedChart,
-  Cell,
-  Brush,
-  BarProps,
-} from 'recharts';
+import { Area, Bar, Brush, Cell, ComposedChart, Legend, Tooltip, XAxis, YAxis } from 'recharts';
 
+import { CustomTooltip } from 'components';
 import { CategoricalChartState } from 'recharts/types/chart/generateCategoricalChart';
 import { ChartData } from 'types/types';
-import { CustomTooltip } from 'components';
 
 interface MainChartProps {
   chartData: ChartData[];
@@ -82,7 +71,7 @@ const MainChart = ({ chartData, selectedCategory, onChange }: MainChartProps) =>
       <Tooltip position={{ y: -10 }} content={CustomTooltip} wrapperStyle={{ outline: 'none' }} />
 
       <XAxis
-        dataKey='date'
+        dataKey='time'
         label={{ value: 'time', position: 'left', offset: 6 }}
         scale='auto'
         minTickGap={30}
@@ -128,7 +117,7 @@ const MainChart = ({ chartData, selectedCategory, onChange }: MainChartProps) =>
         stroke='#ffb700'
       />
 
-      <Brush dataKey='date' height={30} stroke='#5388D899' />
+      <Brush dataKey='time' height={30} stroke='#5388D899' />
 
       <defs>
         <linearGradient id={DataLabel.area} x1='0' y1='1.5' x2='0' y2='0'>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,15 +1,16 @@
-import React, { useState, useEffect } from 'react';
 import { Box, Flex, Heading, Stack, Text } from '@chakra-ui/react';
+import { FilterButtons, MainChart, MainLayout } from 'components';
+import { useEffect, useState } from 'react';
 import { useLoaderData, useSearchParams } from 'react-router-dom';
-import { FilterButtons, MainLayout, MainChart } from 'components';
-import { ChartData } from 'types/types';
+import { ChartDataByDay } from 'types/types';
 
 const MainPage = () => {
-  const mockData = useLoaderData() as ChartData[];
+  const chartData = useLoaderData() as ChartDataByDay;
+  const chartDays = Object.keys(chartData);
+  const selectedDay = chartDays[chartDays.length - 1];
+  const areaCategory = Array.from(new Set<string>(chartData[selectedDay].map(data => data.id)));
 
   const [query] = useSearchParams();
-  const areaCategory = Array.from(new Set<string>(mockData.map(data => data.id)));
-  const [date] = mockData[0].date.split(' ');
   const [selectedCategory, setSelectedCategory] = useState<string[]>([]);
 
   useEffect(() => {
@@ -18,8 +19,8 @@ const MainPage = () => {
 
   return (
     <MainLayout>
-      <Heading size={'lg'}>{date}</Heading>
-      <Text marginBottom={2}>{date} 에 수집된 정보 시각화 차트</Text>
+      <Heading size={'lg'}>{selectedDay}</Heading>
+      <Text marginBottom={2}>{selectedDay} 에 수집된 정보 시각화 차트</Text>
       <Flex direction='column'>
         <Text marginBottom='1' fontSize='.9rem' color='gray.400' fontWeight='700'>
           ID 필터링
@@ -35,7 +36,7 @@ const MainPage = () => {
         </Box>
       </Flex>
       <MainChart
-        chartData={mockData}
+        chartData={chartData[selectedDay]}
         onChange={setSelectedCategory}
         selectedCategory={selectedCategory}
       />

--- a/src/router/loader/mainLoader.ts
+++ b/src/router/loader/mainLoader.ts
@@ -1,3 +1,4 @@
+import { ChartData, ChartDataByDay, ChartDataResponse } from 'types/types';
 import { getChartDataApi } from 'utils/api/chart';
 
 const mainLoader = async () => {
@@ -5,11 +6,20 @@ const mainLoader = async () => {
     data: { response },
   } = await getChartDataApi();
 
-  const convertObjectToArray = Object.keys(response).map(mockDataKey => {
-    const { value_bar } = response[mockDataKey];
-    return { ...response[mockDataKey], date: mockDataKey, value_bar: value_bar / 1000 };
-  });
+  const responseToChartData: ChartData[] = Object.entries(response as ChartDataResponse).map(
+    ([key, value]) => {
+      const dateTime = key.split(' ');
+      return { date: dateTime[0], time: dateTime[1], ...value, value_bar: value.value_bar / 100 };
+    },
+  );
 
-  return convertObjectToArray;
+  const init: ChartDataByDay = {};
+  const chartDataByDay = responseToChartData.reduce((prev, curr) => {
+    prev[curr.date] = prev[curr.date] || [];
+    prev[curr.date].push(curr);
+    return prev;
+  }, init);
+
+  return chartDataByDay;
 };
 export default mainLoader;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,6 +1,18 @@
 export interface ChartData {
   date: string;
+  time: string;
   id: string;
   value_area: number;
   value_bar: number;
+}
+export interface ChartDataByDay {
+  [key: string]: ChartData[];
+}
+
+export interface ChartDataResponse {
+  [date: string]: {
+    id: string;
+    value_area: number;
+    value_bar: number;
+  };
 }


### PR DESCRIPTION
## 요구사항
이후 확장성을 위하여 데이터를 일자별로 정리하는 기능을 추가
다른 일자가 들어오는 경우 selectedDay를 상태값으로 변경 및 select 박스로 변경하면 쉽게 사용 가능

## 구현 사항 설명
차트를 일자별로 그릴 수 있도록 Loader에서 데이터 가공